### PR TITLE
Pass hashfunction to hkdf extract and expand

### DIFF
--- a/CryCollege/week6/hkdf.py
+++ b/CryCollege/week6/hkdf.py
@@ -20,9 +20,9 @@ def hkdf_expand(prk, info, length, hashfunc=BLAKE2s):
 
 
 def hkdf(ikm, salt, info, output_length, hashfunc=BLAKE2s):
-    prk = hkdf_extract(salt, ikm)
+    prk = hkdf_extract(salt, ikm, hashfunc)
     print("prk: ", prk)
-    return hkdf_expand(prk, info, output_length)
+    return hkdf_expand(prk, info, output_length, hashfunc)
 
 
 def test_hkdf():


### PR DESCRIPTION
Without this change, extract and expand will still use BLAKE2s even if, for example, SHA256 is chosen in the calling function.